### PR TITLE
[#208] 드롭다운 메뉴에서 담당자 선택 안되는 오류

### DIFF
--- a/hooks/DropDown/useDropDown.ts
+++ b/hooks/DropDown/useDropDown.ts
@@ -21,7 +21,7 @@ function useDropDown({ onChange }: Props) {
 
   const card = queryClient.getQueryData(['card', cardId]);
   const cardData = card as GetCardDetailsItem;
-  const member = queryClient.getQueryData(['member']);
+  const member = queryClient.getQueryData(['membersInDashboard', 1]);
   const members = member as GetMembersInDashboardItem;
 
   const openMenu = () => {
@@ -54,7 +54,7 @@ function useDropDown({ onChange }: Props) {
 
   useEffect(() => {
     onChange('담당자', inputData);
-  }, [inputData, onChange]);
+  }, [inputData]);
 
   useEffect(() => {
     setInputData(cardData?.assignee.nickname);


### PR DESCRIPTION
## ✅ 작업 내용
- [x] 담당자 선택 오류 해결

## 📍 리뷰 포인트
- React-Query 적용하면서 `querykey`가 변경 되면서 API로 받아오는 값을 못 받아오고 있었습니다.

### 기존 화면
<img width="250" alt="스크린샷 2024-02-18 오후 4 47 04" src="https://github.com/CodeJaws/Jawstify/assets/49686619/b8f5b0cc-ec01-42bb-82c7-cb9f783ee7d1">

### 수정 화면
<img width="269" alt="스크린샷 2024-02-18 오후 4 47 24" src="https://github.com/CodeJaws/Jawstify/assets/49686619/639b6ea6-66f7-43cf-af83-a56dd7b05ee7">


### 기존코드
```
const member = queryClient.getQueryData(['member']);
```

### 수정 코드
```
const member = queryClient.getQueryData(['membersInDashboard', 1]);
```

## 👀 기타 사항
- 빠른 어푸 부탁드립니다..!
- 다들 지금 진행 하시는 프로젝트도 화이팅입니다👍🏻

